### PR TITLE
version lock all components and tag for 1.0.0-rc2

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -11,33 +11,34 @@
     <!-- build scripts -->
     <project name="armpelionedge/build-pelion-os-edge"
         path="build-env"
+        revision="refs/tags/1.0.0-rc2"
         remote="github" />
 
     <!-- yocto core -->
     <project name="poky"
         path="poky"
-        revision="thud"
+        revision="thud-20.0.2"
         remote="yocto" />
 
     <project name="meta-openembedded"
         path="poky/meta-openembedded"
-        revision="thud"
+        revision="4cd3a39f22a2712bfa8fc657d09fe2c7765a4005"
         remote="oe" />
 
     <project name="meta-virtualization"
         path="poky/meta-virtualization"
-        revision="thud"
+        revision="9b568b6ae1bf1bebcb9552703ee40f9b880e07ed"
         remote="yocto" />
 
     <project name="meta-security"
         path="poky/meta-security"
-        revision="thud"
+        revision="31dc4e7532fa7a82060e0b50e5eb8d0414aa7e93"
         remote="yocto" />
 
     <!-- bsps -->
     <project name="meta-raspberrypi"
         path="poky/meta-raspberrypi"
-        revision="thud"
+        revision="c71d79efc5a06a0c896c278c94f5b14413bb4d69"
         remote="yocto" />
 
     <!-- distros -->
@@ -45,11 +46,12 @@
     <!-- software -->
     <project name="armpelionedge/meta-pelion-os-edge"
         path="poky/meta-pelion-os-edge"
+        revision="refs/tags/1.0.0-rc2"
         remote="github" />
 
     <project name="aaronovz1/meta-nodejs"
         path="poky/meta-nodejs"
-        revision="pyro"
+        revision="5401bb427680ad483cf094d7ce7264f1c4128800"
         remote="github" />
 
 </manifest>


### PR DESCRIPTION
Don't merge this until after https://github.com/armPelionEdge/meta-pelion-os-edge/pull/70 is merged and tagged 1.0.0-rc2.