### PR TITLE
Use warrior version

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -50,7 +50,7 @@
     <!-- software -->
     <project name="armpelionedge/meta-pelion-edge"
         path="poky/meta-pelion-edge"
-        revision="warrior"
+        revision="dev"
         remote="github" />
 
     <project name="openembedded/meta-linaro"

--- a/default.xml
+++ b/default.xml
@@ -17,28 +17,28 @@
     <!-- yocto core -->
     <project name="poky"
         path="poky"
-        revision="thud"
+        revision="refs/tags/warrior-21.0.0"
         remote="yocto" />
 
     <project name="meta-openembedded"
         path="poky/meta-openembedded"
-        revision="thud"
+        revision="warrior"
         remote="oe" />
 
     <project name="meta-virtualization"
         path="poky/meta-virtualization"
-        revision="thud"
+        revision="warrior"
         remote="yocto" />
 
     <project name="meta-security"
         path="poky/meta-security"
-        revision="thud"
+        revision="mut"
         remote="yocto" />
 
     <!-- bsps -->
     <project name="meta-raspberrypi"
         path="poky/meta-raspberrypi"
-        revision="thud"
+        revision="warrior"
         remote="yocto" />
 
     <project name="armmbed/meta-mbl"
@@ -50,12 +50,13 @@
     <!-- software -->
     <project name="armpelionedge/meta-pelion-edge"
         path="poky/meta-pelion-edge"
+        revision="warrior"
         remote="github" />
 
     <project name="openembedded/meta-linaro"
         path="poky/meta-linaro"
         remote="linaro"
-        revision="thud" />
+        revision="warrior" />
 
     <project name="aaronovz1/meta-nodejs"
         path="poky/meta-nodejs"

--- a/default.xml
+++ b/default.xml
@@ -44,7 +44,7 @@
     <project name="armmbed/meta-mbl"
         path="poky/meta-mbl"
         remote="github"
-        revision="thud-gateway-bsp" />
+        revision="warrior-dev" />
     <!-- distros -->
 
     <!-- software -->


### PR DESCRIPTION
This updates many dependencies to use the warrior branch. This may need
to be modified once the `warrior` branch is merged https://github.com/armPelionEdge/meta-pelion-edge/pull/84