### PR TITLE
Update default.xml

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -12,7 +12,7 @@
     <!-- build scripts -->
     <project name="armpelionedge/build-pelion-edge"
         path="build-env"
-        revision="refs/tags/2.0.0-rc1"
+        revision="6b05b7d48fd0be95feb89bcd068b4eb3272b106b"
         remote="github" />
 
     <!-- yocto core -->
@@ -51,7 +51,7 @@
     <!-- software -->
     <project name="armpelionedge/meta-pelion-edge"
         path="poky/meta-pelion-edge"
-        revision="refs/tags/2.0.0-rc1"
+        revision="c6b266acb41d392f26d96987ed7e7956a901d644"
         remote="github" />
 
     <project name="openembedded/meta-linaro"


### PR DESCRIPTION
Today, the tags `2.0.0-rc1` in build-pelion-edge and meta-pelion-edge point these revisions, they were updated in August 2019
build-pelion-edge: 877b409f717bd05bb60cb540037f2d6e55f91d1e
meta-pelion-edge: 65c07816dfae3fe98f1f2b4ebf4281476fcd0d9d
However, to build manifest-pelion-edge 2.0.0 successfully, these must point
build-pelion-edge: 6b05b7d48fd0be95feb89bcd068b4eb3272b106b
meta-pelion-edge: c6b266acb41d392f26d96987ed7e7956a901d644

For details, see the comments in internal JIRA `IOTCUST-243`.