### PR TITLE
Updated meta-security to point to dunfell commit SHA

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -30,13 +30,13 @@
 
     <project name="meta-security"
         path="poky/meta-security"
-        revision="98ff502d4096331e2b8a8e4044860b23bf6f8ea5"
-	remote="yocto" />
+        revision="c74cc97641fd93e0e7a4383255e9a0ab3deaf9d7"
+        remote="yocto" />
 
     <project name="pelioniot/meta-parsec"
-	path="poky/meta-parsec"
-	revision="refs/heads/dev"
-	remote="github" />
+        path="poky/meta-parsec"
+        revision="refs/heads/dev"
+        remote="github" />
 
     <!-- Edge core parsec client deps -->
     <project name="meta-rust/meta-rust"


### PR DESCRIPTION
We have to do this otherwise ibmswtpm2 build fails with QA errors -
`QA Issue: File /usr/bin/tpm_server in package ibmswtpm2 doesn't have GNU_HASH (didn't pass LDFLAGS?) [ldflags]`

Although, I noticed that this pulls in the old version of ibmswtpm2 1563 (current SHA bring 1628)