### PR TITLE
Use ssh as meta-parsec is private

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -2,7 +2,7 @@
 <manifest>
 
     <!-- remotes -->
-    <remote name="github" fetch="https://github.com/" />
+    <remote name="github" fetch="ssh://git@github.com/" />
     <remote name="yocto" fetch="https://git.yoctoproject.org/git" />
     <remote name="oe" fetch="https://git.openembedded.org/" />
 


### PR DESCRIPTION
In order to create 2.3-RC1, we have to use ssh to pull in meta-parsec until we take it public. 